### PR TITLE
Detect model changes & update chart without regenerating it

### DIFF
--- a/angular-c3.js
+++ b/angular-c3.js
@@ -7,33 +7,32 @@ angular.module('c3', [])
   console.log('loading directive');
 
   function getUnload(prev, curr) {
-    var prevKeys;
-    if (prev && prev.columns && prev.columns.length) {
-      prevKeys = {};
-      prev.columns.forEach(function(data) {
-        prevKeys[data[0]] = true;
-      });
-    } else if (prev && prev.rows && prev.rows.length) {
-      prevKeys = {};
-      prev.rows[0].forEach(function(key) {
-        prevKeys[key] = true;
-      });
-    } else {
+    function getKeys(src) {
+      var keys;
+      if (src && src.columns && src.columns.length) {
+        keys = {};
+        src.columns.forEach(function(data) {
+          keys[data[0]] = true;
+        });
+        return keys;
+      } else if (src && src.rows && src.rows.length) {
+        keys = {};
+        src.rows[0].forEach(function(key) {
+          keys[key] = true;
+        });
+        return keys;
+      } else {
+        return false;
+      }
+    }
+
+    var prevKeys = getKeys(prev);
+    if (!prevKeys) {
       return false;
     }
 
-    var currKeys;
-    if (curr && curr.columns && curr.columns.length) {
-      currKeys = {};
-      curr.columns.forEach(function(data) {
-        currKeys[data[0]] = true;
-      });
-    } else if (curr && curr.rows && curr.rows.length) {
-      currKeys = {};
-      curr.rows[0].forEach(function(key) {
-        currKeys[key] = true;
-      });
-    } else {
+    var currKeys = getKeys(curr);
+    if (!currKeys) {
       return Object.keys(prevKeys);
     }
 

--- a/angular-c3.js
+++ b/angular-c3.js
@@ -47,20 +47,81 @@ angular.module('c3', [])
     return (delta.length ? delta : false);
   }
 
+  function doHide(chart, data) {
+    var ids;
+    if (data.columns) {
+      ids = data.columns.map(function(d) { return d[0]; });
+    } else if (data.rows) {
+      ids = data.rows[0];
+    }
+
+    var hidden = [];
+    var shown = [];
+    if (!data.hide || !data.hide.length) {
+      ids.forEach(function(id) { shown.push(id); });
+    } else {
+      ids.forEach(function(id) {
+        if (data.hide.indexOf(id) >= 0) {
+          hidden.push(id);
+        } else {
+          shown.push(id);
+        }
+      });
+    }
+
+    if (hidden.length > 0) {
+      chart.hide(hidden);
+    }
+    if (shown.length > 0) {
+      chart.show(shown);
+    }
+
+    // Not exactly sure why this is needed, but without it,
+    // you have legend items stay focused after a hover
+    chart.revert();
+  }
+
+  function toggleData(id, data) {
+    if (data.hide) {
+      var idx = data.hide.indexOf(id);
+      if (idx >= 0) {
+        data.hide.splice(idx, 1);
+      } else {
+        data.hide.push(id);
+      }
+    } else {
+      data.hide = ['id'];
+    }
+  }
+
   return {
     restrict: 'A',
     link: function(scope, elem, attrs) {
       var chart;
       var unwatchFcn = scope.$watch(attrs.c3, function(value, prevValue) {
         if (value) {
-          var config = angular.extend({}, value, { bindto: elem[0] });
+          var config = angular.extend({}, value, {
+            bindto: elem[0],
+            legend: {
+              item: {
+                onclick: function(id) {
+                  if (config.data) {
+                    scope.$apply(function() { toggleData(id, config.data); });
+                  }
+                }
+              }
+            }
+          });
 
           if (!!chart && !!config.data) {
+            // TODO check if data is the only thing changed; if not, then
+            // regenerate the chart rather than call load()
             var unload = getUnload(prevValue.data, config.data);
             if (unload) {
               angular.extend(config.data, {unload: unload});
             }
             chart.load(config.data);
+            doHide(chart, config.data);
           } else {
             chart = c3.generate(config);
           }

--- a/angular-c3.js
+++ b/angular-c3.js
@@ -5,27 +5,78 @@ angular.module('c3', [])
 
 .directive('c3', function() {
   console.log('loading directive');
+
+  function getUnload(prev, curr) {
+    var prevKeys;
+    if (prev && prev.columns && prev.columns.length) {
+      prevKeys = {};
+      prev.columns.forEach(function(data) {
+        prevKeys[data[0]] = true;
+      });
+    } else if (prev && prev.rows && prev.rows.length) {
+      prevKeys = {};
+      prev.rows[0].forEach(function(key) {
+        prevKeys[key] = true;
+      });
+    } else {
+      return false;
+    }
+
+    var currKeys;
+    if (curr && curr.columns && curr.columns.length) {
+      currKeys = {};
+      curr.columns.forEach(function(data) {
+        currKeys[data[0]] = true;
+      });
+    } else if (curr && curr.rows && curr.rows.length) {
+      currKeys = {};
+      curr.rows[0].forEach(function(key) {
+        currKeys[key] = true;
+      });
+    } else {
+      return Object.keys(prevKeys);
+    }
+
+    var delta = [];
+    Object.keys(prevKeys).forEach(function(key) {
+      if (!currKeys.hasOwnProperty(key)) {
+        delta.push(key);
+      }
+    });
+
+    return (delta.length ? delta : false);
+  }
+
   return {
     restrict: 'A',
     link: function(scope, elem, attrs) {
       var chart;
-      var unwatchFcn = scope.$watch(attrs.c3, function(value) {
+      var unwatchFcn = scope.$watch(attrs.c3, function(value, prevValue) {
         if (value) {
           var config = angular.extend({}, value, { bindto: elem[0] });
-          chart = c3.generate(config);
+
+          if (!!chart && !!config.data) {
+            var unload = getUnload(prevValue.data, config.data);
+            if (unload) {
+              angular.extend(config.data, {unload: unload});
+            }
+            chart.load(config.data);
+          } else {
+            chart = c3.generate(config);
+          }
         } else {
           if (chart && typeof chart.destroy === 'function') {
             chart = chart.destroy();
           }
         }
       }, true);
-      
+
       elem.on('$destroy', function() {
         if (chart && typeof chart.destroy === 'function') {
           chart = chart.destroy();
         }
       });
-      
+
       scope.$on('$destroy', function() {
         if (chart && typeof chart.destroy === 'function') {
           chart = chart.destroy();

--- a/angular-c3.js
+++ b/angular-c3.js
@@ -21,6 +21,14 @@ angular.module('c3', [])
           keys[key] = true;
         });
         return keys;
+      } else if (src && src.keys & src.keys.value && src.keys.value.length) {
+        keys = {};
+        if (src.keys.hasOwnProperty('x')) {
+          keys[src.keys.x] = true;
+        }
+        src.keys.value.forEach(function(key) {
+          keys[key] = true;
+        });
       } else {
         return false;
       }
@@ -52,6 +60,8 @@ angular.module('c3', [])
       ids = data.columns.map(function(d) { return d[0]; });
     } else if (data.rows) {
       ids = data.rows[0];
+    } else if (data.keys && data.keys.value) {
+      ids = data.keys.value;
     }
 
     var hidden = [];


### PR DESCRIPTION
Fixes #1, #3 

Instead of regenerating the whole chart, we now use the `chart.load` API to
update existing data IDs & add new data IDs. For removed IDs, the previous &
current data are inspected & the absent IDs are unloaded.

Only `data.columns` & `data.rows` supports the unload detection functionality.
`data.json` can probably be added without much complexity, but `data.url` will
either need `unload:true` or implementation of the 'done' handler.

Similarly, we use the `chart.show` and `chart.hide` APIs to implement 2-way binding
of the `data.hide` model property. Changes to the model will show/hide data as expected,
and showing/hiding by clicking the legend will update the model & trigger a digest.
