### PR TITLE
Detect data model changes, use isolate-scope, fix legend item click behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,43 @@ $scope.chart = {
 ```
 
 The chart is updated whenever the object or any of its properties are modified.
+If the `chart.load()` API can be used, it will be (unless disabled; see Options
+below).
+
+The model can also be watched to catch interactions that change it (e.g.
+clicking legend items to show/hide data).
+
+```javascript
+$scope.$watchCollection('chart.data.hide', function(value, prevValue) {
+  console.log('data.hide changed!');
+});
+```
+
+### Options
+
+Advanced options can also be passed in via the `c3-options` attribute. This
+attribute is optional and specific to the operation
+
+```html
+<div c3="chart" c3-options="options"></div>
+```
+
+```javascript
+$scope.options = {
+  /* If true (default), detect changes to data and use the the load() API
+   * whenever possible to make updates; if false, regenerate the chart on every
+   * change.
+   *
+   * NOTE: because of the additional processing needed to detect loadable vs
+   *       unloadable changes, you may want to set this to false if you have a
+   *       high update rate or very large datasets.
+   */
+  useLoadApi: true
+};
+```
+
+Other options to come as needed.
+
 
 [AngularJS]: https://github.com/angular/bower-angular
 [C3.js]: https://github.com/masayuki0812/c3

--- a/angular-c3.js
+++ b/angular-c3.js
@@ -4,42 +4,60 @@
 angular.module('c3', [])
 
 .directive('c3', function() {
-  console.log('loading directive');
+  function getKeys(src, includeXs) {
+    if (!src) {
+      return false;
+    }
 
-  function getUnload(prev, curr) {
-    function getKeys(src) {
-      var keys;
-      if (src && src.columns && src.columns.length) {
-        keys = {};
-        src.columns.forEach(function(data) {
+    var xs = {};
+    if (src.hasOwnProperty('x')) {
+      xs[src.x] = true;
+    } else if (src.xs && src.xs.length) {
+      angular.forEach(src.xs, function(x) {
+        xs[x] = true;
+      });
+    }
+
+    var keys;
+    if (src.columns && src.columns.length) {
+      keys = {};
+      src.columns.forEach(function(data) {
+        if (!xs[data[0]] || includeXs) {
           keys[data[0]] = true;
-        });
-        return keys;
-      } else if (src && src.rows && src.rows.length) {
-        keys = {};
-        src.rows[0].forEach(function(key) {
-          keys[key] = true;
-        });
-        return keys;
-      } else if (src && src.keys & src.keys.value && src.keys.value.length) {
-        keys = {};
-        if (src.keys.hasOwnProperty('x')) {
-          keys[src.keys.x] = true;
         }
+      });
+      return keys;
+    } else if (src.rows && src.rows.length) {
+      keys = {};
+      src.rows[0].forEach(function(key) {
+        if (!xs[key] || includeXs) {
+          keys[key] = true;
+        }
+      });
+      return keys;
+    } else if (src.keys) {
+      keys = {};
+      if (src.keys.hasOwnProperty('x') && includeXs) {
+        keys[src.keys.x] = true;
+      }
+      if (src.keys.value && src.keys.value.length) {
         src.keys.value.forEach(function(key) {
           keys[key] = true;
         });
-      } else {
-        return false;
       }
+      return keys;
+    } else {
+      return false;
     }
+  }
 
-    var prevKeys = getKeys(prev);
+  function getUnload(prev, curr) {
+    var prevKeys = getKeys(prev, true);
     if (!prevKeys) {
       return false;
     }
 
-    var currKeys = getKeys(curr);
+    var currKeys = getKeys(curr, true);
     if (!currKeys) {
       return Object.keys(prevKeys);
     }
@@ -55,25 +73,25 @@ angular.module('c3', [])
   }
 
   function doHide(chart, data) {
-    var ids;
-    if (data.columns) {
-      ids = data.columns.map(function(d) { return d[0]; });
-    } else if (data.rows) {
-      ids = data.rows[0];
-    } else if (data.keys && data.keys.value) {
-      ids = data.keys.value;
+    // TODO: handle boolean data.hide
+
+    var keys = getKeys(data);
+    if (!keys) {
+      return;
     }
+
+    keys = Object.keys(keys);
 
     var hidden = [];
     var shown = [];
     if (!data.hide || !data.hide.length) {
-      ids.forEach(function(id) { shown.push(id); });
+      keys.forEach(function(key) { shown.push(key); });
     } else {
-      ids.forEach(function(id) {
-        if (data.hide.indexOf(id) >= 0) {
-          hidden.push(id);
+      keys.forEach(function(key) {
+        if (data.hide.indexOf(key) >= 0) {
+          hidden.push(key);
         } else {
-          shown.push(id);
+          shown.push(key);
         }
       });
     }
@@ -91,6 +109,8 @@ angular.module('c3', [])
   }
 
   function toggleData(id, data) {
+    // TODO: handle boolean data.hide
+
     if (data.hide) {
       var idx = data.hide.indexOf(id);
       if (idx >= 0) {
@@ -103,35 +123,133 @@ angular.module('c3', [])
     }
   }
 
+  function hideAllBut(id, data) {
+    // TODO: handle boolean data.hide
+
+    var keys = getKeys(data);
+    if (!keys) {
+      return;
+    }
+
+    if (keys.hasOwnProperty(id)) {
+      delete keys[id];
+    }
+
+    if (data.hide) {
+      data.hide.length = 0;
+      Object.keys(keys).forEach(function(key) {
+        data.hide.push(key);
+      });
+    } else {
+      data.hide = Object.keys(keys);
+    }
+  }
+
+  // Properties that can be passed into chart.load() API ('hide' is included
+  // because we call doHide() in the done callback of load)
+  var loadableDataProps = {
+    hide: true, url: true, columns: true, rows: true, json: true, classes: true,
+    categories: true, axes: true, colors: true, type: true, types: true,
+  };
+
+  function partitionConfig(config) {
+    var result = { loadableData: {}, unloadableData: {}, nonData: {} };
+
+    if (config) {
+      angular.forEach(config, function(value, prop) {
+        if (prop !== 'data') {
+          result.nonData[prop] = value;
+        }
+      });
+
+      if (config.data) {
+        angular.forEach(config.data, function(value, prop) {
+          if (loadableDataProps.hasOwnProperty(prop)) {
+            result.loadableData[prop] = value;
+          } else {
+            result.unloadableData[prop] = value;
+          }
+        });
+      }
+    }
+
+    return result;
+  }
+
+  // return false if can't/shouldn't update the chart using the load API;
+  // otherwise, return an object that can be passed into the .load() call
+  function getLoadParam(options, prevConfig, currConfig) {
+    if (!!options && !options.useLoadApi) {
+      return false;
+    } else {
+      var prev = partitionConfig(prevConfig);
+      var curr = partitionConfig(currConfig);
+
+      // NOTE: no need to compare .loadableData because we're already deep
+      // watching the configs, so the loadableData's must be non-equal
+      if ( angular.equals(prev.nonData,        curr.nonData) &&
+           angular.equals(prev.unloadableData, curr.unloadableData)) {
+
+        var unload = getUnload(prev.loadableData, curr.loadableData);
+        if (unload) {
+          angular.extend(curr.loadableData, {unload: unload});
+        }
+
+        return curr.loadableData;
+      } else {
+        return false;
+      }
+    }
+  }
+
   return {
     restrict: 'A',
-    link: function(scope, elem, attrs) {
+    scope: {
+      c3: '=c3',
+      options: '=?c3Options',
+    },
+    link: function(scope, elem) {
       var chart;
-      var unwatchFcn = scope.$watch(attrs.c3, function(value, prevValue) {
+      scope.$watch('c3', function(value, prevValue) {
         if (value) {
+          var config;
+          var legendOnclick;
+
+          if (value.legend && value.legend.item && value.legend.item.onclick) {
+            legendOnClick = value.legend.item.onclick;
+          }
+
           var config = angular.extend({}, value, {
             bindto: elem[0],
             legend: {
               item: {
                 onclick: function(id) {
-                  if (config.data) {
-                    scope.$apply(function() { toggleData(id, config.data); });
-                  }
+                  var event = this.d3.event;
+                  scope.$apply(function() {
+                    if (typeof legendOnclick === 'function') {
+                      legendOnclick(id);
+                    } else {
+                      if (event.altKey) {
+                        hideAllBut(id, value.data);
+                      } else {
+                        toggleData(id, value.data);
+                      }
+                    }
+                  });
                 }
               }
             }
           });
 
-          if (!!chart && !!config.data) {
-            // TODO check if data is the only thing changed; if not, then
-            // regenerate the chart rather than call load()
-            var unload = getUnload(prevValue.data, config.data);
-            if (unload) {
-              angular.extend(config.data, {unload: unload});
-            }
-            chart.load(config.data);
-            doHide(chart, config.data);
+          var loadParam;
+
+          if (!chart) {
+            chart = c3.generate(config);
+          } else if (loadParam = getLoadParam(scope.options, prevValue, value)) {
+            angular.extend(loadParam, { done: doHide(chart, value.data) });
+            chart.load(loadParam);
           } else {
+            chart.destroy();
             chart = c3.generate(config);
           }
         } else {


### PR DESCRIPTION
Fixes #4, #5, #6

Many fixes and refactorings were made, the main being in how loading/unloading
works: now, it detects whether the load API can be used based on what parts
of the config changed, rather than regenerating the entire chart (or worse, not
updating at all, which was the previous behaviour when non-data fields changed).

The directive now also uses an isolated scope, instead of watching the parent
scope's c3 model. This is just an overdue good practice.

An optional 'c3-options' scope model was also added, which takes an object.
Currently, the only option is '{useLoadApi: true|false}' (default true), which
enables/disables the load API logic and forces full chart regeneration, as a
failsafe in case the current logic has performance/functional issues.

Finally, clicking legend items now mimics the default c3 behaviour: if the
altKey modifier is down, all but the clicked item are hidden.
