### PR TITLE
Add click expressions for chart interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ angular.module('myApp', ['c3'])
 
 In your controller, the object passed into the `c3` attribute is the same as
 that passed into [`c3.generate()`][c3.generate], except without the `bindto`
-property.
+property and without interaction callbacks (see Interaction below).
 
 ```javascript
 $scope.chart = {
@@ -71,10 +71,73 @@ $scope.$watchCollection('chart.data.hide', function(value, prevValue) {
 });
 ```
 
+### Interaction
+
+Interaction with the chart is handled by attributes on the directive, rather
+than callbacks on the `c3` model. This is more consistent with how other Angular
+directives handle events, such as `ng-click`.
+
+For example, in your HTML (excluding the comments):
+
+```html
+<!--
+  c3-data-click
+  Corresponds to data.onclick, with the following expressions available:
+    - datum: Datum clicked (corresponds to 'd' in data.onclick callback)
+    - event: MouseEvent of the click
+
+  c3-legend-click
+  Corresponds to legend.item.onclick, with the following expressions available:
+    - id:      ID of dataset clicked (corresponds to 1st argument in
+               legend.item.onclick callback)
+    - event:   MouseEvent of the click
+    - default: Function performing default legend item click behavior, may be
+               optionally called in your own handler
+-->
+
+<div c3="chart" c3-data-click="dataClicked(datum, event)"
+                c3-legend-click="legendClicked(id, event, default)">
+</div>
+```
+
+And in your controller:
+
+```javascript
+$scope.chart = {
+  data: {
+    columns: [
+      ['data1', 1, 2, 3],
+      ['data2', 4, 5, 6]
+    ]
+  }
+};
+
+$scope.dataClicked = function(d, event) {
+  console.log(d);       // the data point clicked;
+
+  console.log(event);   // the MouseEvent of the click;
+};
+
+$scope.legendClicked = function(id, event, defaultClick) {
+  console.log(id);     // the ID of the dataset clicked;
+
+  console.log(event);  // the MouseEvent of the click;
+
+  defaultClick();      // function performing the default legend click action,
+                       // which may be optionally called
+};
+```
+
+The events currently handled in this way are:
+
+- [`data.onclick`][data.onclick]
+- [`legend.item.onclick`][legend.item.onclick]
+
 ### Options
 
 Advanced options can also be passed in via the `c3-options` attribute. This
-attribute is optional and specific to the operation
+attribute is optional and specific to the operation of this directive; it
+does not correspond to any configuration parameters of C3.js.
 
 ```html
 <div c3="chart" c3-options="options"></div>
@@ -100,3 +163,5 @@ Other options to come as needed.
 [AngularJS]: https://github.com/angular/bower-angular
 [C3.js]: https://github.com/masayuki0812/c3
 [c3.generate]: http://c3js.org/gettingstarted.html#generate
+[data.onclick]: http://c3js.org/reference.html#data-onclick
+[legend.item.onclick]: http://c3js.org/reference.html#legend-item-onclick

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ $scope.chart = {
 ```
 
 The chart is updated whenever the object or any of its properties are modified.
-If the `chart.load()` API can be used, it will be (unless disabled; see Options
-below).
+If the [`load` API][chart.load] can be used, it will be (unless disabled; see
+Options below).
 
 The model can also be watched to catch interactions that change it (e.g.
 clicking legend items to show/hide data).
@@ -163,5 +163,6 @@ Other options to come as needed.
 [AngularJS]: https://github.com/angular/bower-angular
 [C3.js]: https://github.com/masayuki0812/c3
 [c3.generate]: http://c3js.org/gettingstarted.html#generate
+[chart.load]: http://c3js.org/reference.html#api-load
 [data.onclick]: http://c3js.org/reference.html#data-onclick
 [legend.item.onclick]: http://c3js.org/reference.html#legend-item-onclick

--- a/bower.json
+++ b/bower.json
@@ -13,8 +13,8 @@
     "Ali Tavakoli"
   ],
   "dependencies": {
-    "angular": ">=1.3.x",
-    "c3": ">=0.4.x"
+    "angular": "~1.4",
+    "c3": "0.4.10"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #8 

Instead of populating `onclick` functions in the model, events (specifically `data.onclick` and `legend.item.onclick`) are now handled via attributes (`c3-data-click` and `c3-legend-click`, respectively).

This is the "more Angular way" but also was necessary to properly handle events within the correct scope, such as when the `c3` model is changed to an identical one according to `angular.equals`, but with new objects/arrays; this will not trigger the model's `$watch` handler, and can result in the directive having a stale model (which the parent scope's `onclick` handlers may update without the directive responding). Also, the user's controller will need to wrap its callback in `$applyAsync`, which it shouldn't have to worry about.

A simple and likely-to-occur example showing why this change was necessary:

``` javascript
// in my controller...

$scope.chart = {
  data: {
    columns: [...],
    hide: []
  }
};

$scope.unhideData = function() {
  $scope.chart.hide = [];
};
```

If `$scope.chart.data.hide` is already empty when `unhideData` is called, then `hide` will change but because `angular.equals([], [])`, the directive will not know about it and its `onclick` callback will continue to operate on the old, stale version of the `hide` object (meaning changes it makes won't actually take effect). This is avoided when using scope expressions because innocuous model changes won't trigger `$watch` updates as before, but once a meaningful change occurs, it will be handled within the directive, using the directive's scope.

Other changes include:
- `scope.c3` is used whenever possible, rather than any cached or closure'd
  model value; this a good practice in line with the fix above.
- `angular.merge` is used instead of angular.extend to construct the config
  object, meaning that `{legend: {...}}` config parameters are now no longer
  overwritten (excluding, of course, `legend.item.onclick`).
- A new config object is only created when needed (i.e. when the load API
  cannot be used), not on every `$watch` evaluation.
- The internal `toggleData` function was renamed to `toggleHide, which is more
  semantically correct.
- Added link to load API in README.
- Explicit dependency on C3.js version 0.4.10 in `bower.json`, due to assumptions
  made on internal operations to make `MouseEvent` object available to `onclick`
  expressions.
- Updated angularjs dependency to `~1.4` in `bower.json`
